### PR TITLE
bug fixed

### DIFF
--- a/client/src/components/GroupBottomNavigation.tsx
+++ b/client/src/components/GroupBottomNavigation.tsx
@@ -12,7 +12,7 @@ const GroupBottomNavigation: React.FC<GroupBottomNavigationProps> = ({
   activeTab: propsActiveTab,
   groupId,
 }) => {
-  const [activeTab, setActiveTab] = useState(propsActiveTab || '약속');
+  const [activeTab, setActiveTab] = useState(propsActiveTab);
 
   return (
     <Nav>

--- a/client/src/components/GroupHeader.tsx
+++ b/client/src/components/GroupHeader.tsx
@@ -11,7 +11,7 @@ const GroupHeader: React.FC<GroupHeaderProps> = ({ title }) => {
   const router = useRouter();
 
   const handleBack = () => {
-    router.back();
+    router.push('/groups');
   };
 
   return (

--- a/client/src/components/MainBottomNavigation.tsx
+++ b/client/src/components/MainBottomNavigation.tsx
@@ -10,7 +10,7 @@ interface MainBottomNavigationProps {
 const MainBottomNavigation: React.FC<MainBottomNavigationProps> = ({
   activeTab: propsActiveTab,
 }) => {
-  const [activeTab, setActiveTab] = useState(propsActiveTab || '홈');
+  const [activeTab, setActiveTab] = useState(propsActiveTab);
 
   return (
     <Nav>


### PR DESCRIPTION
go back to groups by clicking back arrow of group header

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **변경 사항**
	- `GroupHeader` 컴포넌트에서 '뒤로 가기' 버튼 클릭 시, 이전 페이지 대신 `/groups` 경로로 명확하게 리디렉션되는 기능이 추가되었습니다.
	- `GroupBottomNavigation` 및 `MainBottomNavigation` 컴포넌트에서 `activeTab` 상태가 `propsActiveTab`으로만 초기화되도록 변경되어, 기본값 설정이 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->